### PR TITLE
Background container div subsituted by before: on main

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -28,18 +28,12 @@ export default function App({ Component, pageProps, router }: AppProps) {
     <>
       <ThemeProvider attribute="class">
         <div className={`${GeistSans.className}`}>
-          <div className="fixed inset-0 flex justify-center sm:px-8">
-            <div className="flex w-full max-w-7xl lg:px-8">
-              <div className="w-full bg-white ring-1 ring-zinc-100 dark:bg-zinc-900 dark:ring-zinc-300/20" />
-            </div>
-          </div>
-          <div className="relative">
-            <Header />
-            <main>
-              <Component previousPathname={previousPathname} {...pageProps} />
-            </main>
-            <Footer />
-          </div>
+          <Header />
+          <main className="before:fixed before:inset-0 before:ring-1 before:ring-zinc-100 before:bg-white dark:before:ring-zinc-300/20 dark:before:bg-zinc-900 before:w-full sm:before:w-[min(100%-4rem,76rem)] before:mx-auto">
+            <Component previousPathname={previousPathname} {...pageProps} />
+          </main>
+          <Footer />
+
           <Analytics />
         </div>
       </ThemeProvider>


### PR DESCRIPTION
Just to avoid having unnecessary markup, I deleted the div that was fixed to create the background of the content, and instead I just used the :before sudo element to style the background of the content.

it has a little jump in a very specific range of width, but unless you are testing and dragging the window back and forward no one should notice any difference. (actually with this change you avoid to see the breakpoint jump)